### PR TITLE
fix: add When criteria for Advanced and Deep effort levels

### DIFF
--- a/versions/TheAlgorithm_Latest.md
+++ b/versions/TheAlgorithm_Latest.md
@@ -53,8 +53,8 @@ You have the user's request. You have the loaded context. THINK about it. Don't 
   | **Fast** | <1min | "quickly", simple fix, skill invocation | OBSERVE 10s, BUILD 20s, EXECUTE 20s, VERIFY 10s |
   | **Standard** | <2min | Normal request, no time pressure stated | OBSERVE 15s, THINK 15s, BUILD 30s, EXECUTE 30s, VERIFY 20s |
   | **Extended** | <8min | Still needed relatively fast, but quality must be extraordinary | Full phases, checkpoints every 1 min |
-  | **Advanced** | <16min | Full phases, checkpoints every 1 min |
-  | **Deep** | <32min | Full phases, checkpoints every 1 min |
+  | **Advanced** | <16min | Multi-system changes, cross-cutting concerns, significant refactors | Full phases, checkpoints every 1 min |
+  | **Deep** | <32min | Architectural decisions, novel problem domains, research-heavy work | Full phases, checkpoints every 1 min |
   | **Comprehensive** | <120m | Don't feel rushed by time |
   | **Loop** | Unbounded | External loop, PRD iteration not really the same as regular Algorithm execution |
   **DEFAULT IS STANDARD (~2min).** Faster than regular execution, not slower, but higher quality. Only escalate if request DEMANDS depth.


### PR DESCRIPTION
## Problem

The effort level table has two issues with the Advanced and Deep rows (lines 56-57 of `TheAlgorithm_Latest.md`):

1. **No When criteria** — both say "Full phases, checkpoints every 1 min", which is Phase Budget Guide content accidentally placed in the When column. This makes them indistinguishable.

2. **Malformed rows** — both have 3 cells but the header has 4 columns (Tier, Budget, When, Phase Budget Guide).

Fixes #6.

## Fix

Add differentiated When criteria and move "Full phases, checkpoints every 1 min" to the Phase Budget Guide column:

| Tier | When (before) | When (after) |
|---|---|---|
| Advanced | *(empty — Phase Budget Guide content was here)* | Multi-system changes, cross-cutting concerns, significant refactors |
| Deep | *(empty — same)* | Architectural decisions, novel problem domains, research-heavy work |

The distinguishing axis: **Advanced = wide scope** (many files, cross-cutting), **Deep = novel depth** (research, competing approaches, design decisions). This creates a clear gradient:

Extended → *quality-focused* → Advanced → *scope-driven* → Deep → *novelty-driven* → Comprehensive → *unconstrained*
