### PR TITLE
feat(red-lines): add assertion verification and scope lock (v1.7.0)

### DIFF
--- a/versions/TheAlgorithm_Latest.md
+++ b/versions/TheAlgorithm_Latest.md
@@ -1202,6 +1202,8 @@ Check background agent output with Read tool on the output_file path.
 - **No build drift (v1.3.0).** Re-read [CRITICAL] ISC criteria BEFORE creating artifacts. Check [CRITICAL] anti-criteria AFTER each artifact. Never build on autopilot while ISC criteria sit unread.
 - **No rubber-stamp verification (v1.3.0).** Every VERIFY claim requires SPECIFIC evidence. Numeric criteria need actual computed values. Anti-criteria need specific checks performed. "PASS" without evidence = violation.
 - **No orphaned PASS claims (v1.6.0).** Writing "PASS" or "verified" in prose without calling TaskUpdate(completed) is a violation. Every PASS claim MUST be accompanied by a TaskUpdate call. The VERIFY COMPLETION GATE catches missed calls — but this red line means you should never need it.
+- **No unverified factual assertions (v1.7.0).** Before stating ANY current-state fact — prices, service status, API behavior, software licensing, deployment state, what's visible in a UI — verify it with a tool call first. Stating a guess as fact is a trust violation equivalent to rubber-stamp verification. If you cannot verify, say "I haven't verified this." This applies in every phase, not just VERIFY.
+- **No scope expansion without approval (v1.7.0).** The ISC defined at the end of PLAN is the complete scope of work. If you discover adjacent work during EXECUTE (cleanup, bonus features, extra data pulls, convenience additions), STOP and ask before doing it. "Explore X" = find and report. "Fix X" = fix that specific thing. Neither authorizes building Y. Test before any unplanned action: "Did the user explicitly request this?" If no → ask.
 
 ALWAYS. USE. THE. ALGORITHM. AND. PROPER. OUTPUT. FORMAT. AND. INVOKE. CAPABILITIES.
 


### PR DESCRIPTION
Closes #11

## What

Adds two red lines to the existing enforcement section, versioned as v1.7.0 additions:

**No unverified factual assertions** — Before stating any current-state fact (prices, service status, API behavior, licensing, deployment state, UI contents), verify with a tool call first. If you can't verify, say so. This closes a gap where the existing "No rubber-stamp verification" red line covered VERIFY phase evidence but not confident factual claims made earlier in the run.

**No scope expansion without approval** — The ISC at end of PLAN is the complete work scope. Discovering adjacent work during EXECUTE (cleanup, bonus features, unrequested data pulls) requires asking before acting. Complements the ISC Quality Gate, which enforces completeness entering BUILD but provides no symmetric containment during execution.

## Why these placement and wording choices

Both follow the same structure as the existing red lines (behavior described, violation defined, v-tagged). They sit after the v1.6.0 orphaned-PASS rule, which is the natural extension point as the most recently added enforcement.

"Explore X = find and report. Fix X = fix that specific thing." is intentionally concrete — vague rules don't change behavior.

## Evidence

Derived from analysis of 51 failure captures and 78 algorithm reflections over a 30-day window. Both patterns produced avg sentiment 3.0–3.1/10 vs 5.1/10 overall — the two lowest-rated behavioral failure classes in the dataset. The unverified assertion pattern appeared in 7+ distinct incidents across multiple domains (market data, software licensing, infrastructure state).